### PR TITLE
Add missing translations

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
   <meta name="description" content="">
 
   <title>
-    NHS JP Stats
+    <%= I18n.t('app.name') %>
   </title>
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
@@ -22,7 +22,7 @@
 <body>
 
   <nav class="navbar sticky-top flex-md-nowrap">
-    <a href='/'>Job Plan Stats</a>
+    <a href='/'><%= I18n.t('app.name') %></a>
   </nav>
 
   <main>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,14 +1,14 @@
 <div>
   <p>
-    You can use this service to:
+    <%= I18n.t('home.you_can') %>
   </p>
 
   <ul>
     <li>
-      Compare job plans versus actual time spent with patients.
+      <%= I18n.t('home.compare_plan_with_actuals') %>
     </li>
     <li>
-      Quickly spot service and data collection problems.
+      <%= I18n.t('home.drill_down') %>
     </li>
   </ul>
 

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -1,4 +1,6 @@
 en:
+  app:
+    name: NHS Job Plan Stats
   auth:
     log_in: Log in
     log_out: Log out
@@ -7,6 +9,10 @@ en:
       name:
         - Job Plan sessions
         - RIO sessions
+  home:
+    compare_plan_with_actuals: Compare job plans versus actual time spent with patients.
+    drill_down: Drill down to find service and data collection problems.
+    you_can: 'You can use this service to:'
   time:
     formats:
       iso8601_utc: '%Y-%m-%dT%H:%M:%S.000Z'


### PR DESCRIPTION
Let's keep everything translated, so it's easy to create a new version for Welsh etc.. Add translations for:

- App name
- Text on homepage