### PR TITLE
Turbolinks webpack fix

### DIFF
--- a/app/javascript/graphs/bar_chart.js
+++ b/app/javascript/graphs/bar_chart.js
@@ -2,13 +2,16 @@ import Chart from 'chart.js'
 import Rails from '@rails/ujs'
 
 window.addEventListener('turbolinks:load', () => {
-  Rails.ajax({
-    url: data_url(),
-    type: 'GET',
-    success: function(data) {
-      bar_chart(document.getElementById('bar-chart'), data.bar_chart)
-    }
-  });
+  var context
+  if (context = document.getElementById('bar-chart')) {
+    Rails.ajax({
+      url: data_url(),
+      type: 'GET',
+      success: function(data) {
+        bar_chart(context, data.bar_chart)
+      }
+    });
+  }
 });
 
 function bar_chart(context, data) {

--- a/app/javascript/graphs/line_graph.js
+++ b/app/javascript/graphs/line_graph.js
@@ -2,13 +2,16 @@ import Chart from 'chart.js'
 import Rails from '@rails/ujs'
 
 window.addEventListener('turbolinks:load', () => {
-  Rails.ajax({
-    url: data_url(),
-    type: 'GET',
-    success: function(data) {
-      line_graph(document.getElementById('line-graph'), data.line_graph)
-    }
-  });
+  var context;
+  if (context = document.getElementById('line-graph')) {
+    Rails.ajax({
+      url: data_url(),
+      type: 'GET',
+      success: function(data) {
+        line_graph(context, data.line_graph)
+      }
+    });
+  }
 });
 
 function line_graph(context, data) {

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -5,3 +5,10 @@ import 'bootstrap'
 import '../stylesheets/application'
 
 require.context('../images', true)
+
+// Load all JS on every page here, via this single entry point.
+// It's possible to do this better, either conditionally, or with separate packs,
+// but there are lots of gotchas for potentially minimal performance gain.
+// Currently on step 1 of this: https://stackoverflow.com/a/59495659/4741698
+import '../graphs/bar_chart'
+import '../graphs/line_graph'

--- a/app/views/dashboard/individuals.html.erb
+++ b/app/views/dashboard/individuals.html.erb
@@ -56,5 +56,3 @@
   </div>
 
 </div>
-
-<%= javascript_pack_tag 'graphs/bar_chart', 'data-turbolinks-track': 'reload' %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -34,6 +34,3 @@
     </div>
   </div>
 </div>
-
-<%= javascript_pack_tag 'graphs/bar_chart', 'data-turbolinks-track': 'reload' %>
-<%= javascript_pack_tag 'graphs/line_graph', 'data-turbolinks-track': 'reload' %>


### PR DESCRIPTION
Following step 1 of this stackoverflow answer: [https://stackoverflow.com/a/59495659/4741698](https://stackoverflow.com/a/59495659/4741698)

- Add all javascript via a single entry point ('pack'), `application.js`
- Move `javascript/packs/graphs/*` to `javascript/graphs/*`, so they are only fetched through `application.js`
- Check in individual graph files if they're needed based on dom elements to attach to

If performance becomes a problem we can move through those steps.