### PR TITLE
Cache graphs

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -5,9 +5,10 @@ class DashboardController < ApplicationController
     respond_to do |format|
       format.html
       format.json do
-        render json: @presenter.to_json(
-          graphs: [{ type: :line_graph, data: :admin_data }]
-        )
+        json = Rails.cache.fetch('admin') do
+          @presenter.to_json(graphs: [{ type: :line_graph, data: :admin_data }])
+        end
+        render json: json
       end
     end
   end
@@ -18,9 +19,10 @@ class DashboardController < ApplicationController
     respond_to do |format|
       format.html
       format.json do
-        render json: @presenter.to_json(
-          graphs: [{ type: :line_graph, data: :team_data }]
-        )
+        json = Rails.cache.fetch('teams') do
+          @presenter.to_json(graphs: [{ type: :line_graph, data: :team_data }])
+        end
+        render json: json
       end
     end
   end
@@ -31,9 +33,10 @@ class DashboardController < ApplicationController
     respond_to do |format|
       format.html
       format.json do
-        render json: @presenter.to_json(
-          graphs: [{ type: :bar_chart, data: :individual_data }]
-        )
+        json = Rails.cache.fetch('individuals') do
+          @presenter.to_json(graphs: [{ type: :bar_chart, data: :individual_data }])
+        end
+        render json: json
       end
     end
   end
@@ -41,6 +44,6 @@ class DashboardController < ApplicationController
   private
 
   def dashboard_params
-    params.permit(:user_ids, :plan_id, :actual_id)
+    params.permit(:format, :page, :user_ids, :plan_id, :actual_id)
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,20 +13,12 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
-  # Enable/disable caching. By default caching is disabled.
-  # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp/caching-dev.txt').exist?
-    config.action_controller.perform_caching = true
+  config.action_controller.perform_caching = true
 
-    config.cache_store = :memory_store
-    config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.to_i}"
-    }
-  else
-    config.action_controller.perform_caching = false
-
-    config.cache_store = :null_store
-  end
+  config.cache_store = :memory_store
+  config.public_file_server.headers = {
+    'Cache-Control' => "public, max-age=#{2.days.to_i}"
+  }
 
   # Store uploaded files on the local file system
   # (see config/storage.yml for options)


### PR DESCRIPTION
- Add a bit of Redis caching for the graphs, they're maxing out the Heroku database otherwise (capped at 3600 DB requests per hour)