### PR TITLE
#174987522 Ability to add users and leads to groups

### DIFF
--- a/app/controllers/admin/user_groups_controller.rb
+++ b/app/controllers/admin/user_groups_controller.rb
@@ -46,7 +46,8 @@ module Admin
     def user_group_params
       params.require(:user_group).permit(
         :name,
-        :group_type_id
+        :group_type_id,
+        memberships_attributes: %i[role id]
       )
     end
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -47,7 +47,8 @@ module Admin
         :first_name,
         :last_name,
         :email,
-        :admin
+        :admin,
+        user_group_ids: []
       )
     end
   end

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -11,6 +11,7 @@
 class UserGroup < ApplicationRecord
   belongs_to :group_type
   has_many :memberships, dependent: :destroy
+  accepts_nested_attributes_for :memberships
   has_many :users, through: :memberships
 
   validates :name, presence: true, uniqueness: { scope: :group_type }

--- a/app/views/admin/group_types/_group_type_table.html.erb
+++ b/app/views/admin/group_types/_group_type_table.html.erb
@@ -19,35 +19,33 @@
     </thead>
     <tbody>
       <% group_type.user_groups.each do |user_group| %>
-        <% cache user_group do %>
-          <tr>
-            <td>
-              <%= user_group.name %>
-            </td>
-            <td>
-              <% user_group.memberships.where(role: 'lead').each do |membership| %>
-                <%= membership.user.name %>
-                <br>
-              <% end %>
-            </td>
-            <td>
-              <% user_group.memberships.where(role: 'user').each do |membership| %>
-                <%= membership.user.name %>
-                <br>
-              <% end %>
-            </td>
-            <td>
-              <%= link_to [:edit, :admin, user_group], class: 'btn btn-link' do %>
-                <%= icon('pencil') %>
-              <% end %>
-            </td>
-            <td>
-              <%= link_to [:admin, user_group], class: 'btn btn-link', method: :delete, data: { confirm: I18n.t('user_groups.confirm') } do %>
-                <%= icon('trash') %>
-              <% end %>
-            </td>
-          </tr>
-        <% end %>
+        <tr>
+          <td>
+            <%= user_group.name %>
+          </td>
+          <td>
+            <% user_group.memberships.where(role: 'lead').each do |membership| %>
+              <%= membership.user.name %>
+              <br>
+            <% end %>
+          </td>
+          <td>
+            <% user_group.memberships.where(role: 'user').each do |membership| %>
+              <%= membership.user.name %>
+              <br>
+            <% end %>
+          </td>
+          <td>
+            <%= link_to [:edit, :admin, user_group], class: 'btn btn-link' do %>
+              <%= icon('pencil') %>
+            <% end %>
+          </td>
+          <td>
+            <%= link_to [:admin, user_group], class: 'btn btn-link', method: :delete, data: { confirm: I18n.t('user_groups.confirm') } do %>
+              <%= icon('trash') %>
+            <% end %>
+          </td>
+        </tr>
       <% end %>
     </tbody>
   </table>

--- a/app/views/admin/user_groups/edit.html.erb
+++ b/app/views/admin/user_groups/edit.html.erb
@@ -12,6 +12,20 @@
     <div class='col-12'>
       <%= bootstrap_form_for [:admin, @user_group] do |f| %>
         <%= f.text_field :name, label: I18n.t('user_groups.labels.name'), placeholder: I18n.t('user_groups.labels.name'), required: true %>
+
+        <%= f.fields_for :memberships, @user_group.memberships.order(role: :desc) do |mf| %>
+          <% user = mf.object.user %>
+          <div class='row'>
+            <div class='col-4'>
+              <%= user.name %>
+            </div>
+            <div class='col-8'>
+              <% Membership::roles.keys.reverse.each do |role_name| %>
+                <%= mf.radio_button :role, role_name, inline: true, label: I18n.t("user_groups.labels.#{role_name}") %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>  
         <%= f.submit I18n.t('user_groups.save'), class: 'btn btn-primary', style: 'margin-top: 10px;' %>
         <%= link_to I18n.t('user_groups.cancel'), :back, class: 'btn btn-outline-secondary mt-2' %>
       <% end %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -19,6 +19,19 @@
         <%= f.text_field :last_name, label: I18n.t('users.labels.last_name'), placeholder: I18n.t('users.labels.last_name'), required: true %>
         <%= f.text_field :email, label: I18n.t('users.labels.email'), placeholder: I18n.t('users.labels.email'), required: true %>
         <%= f.check_box :admin, label: I18n.t('users.labels.admin'), placeholder: I18n.t('users.labels.admin') %>
+        <br>
+        <% GroupType.all.each do |group_type| %>
+          <% next unless group_type.user_groups.any? %>
+          <p>
+            <%= f.label group_type.name, for: "group_type_#{group_type.id}" %>
+            <br>
+            <%= select_tag 'user[user_group_ids][]',
+                  options_from_collection_for_select(group_type.user_groups, :id, :name, selected: @user.user_groups.pluck(:id)),
+                  id: "group_type_#{group_type.id}",
+                  include_blank: true %>
+            <br>
+          </p>
+        <% end %>
 
         <%= f.submit I18n.t('users.save'), class: 'btn btn-primary mt-2' %>
         <%= link_to I18n.t('users.cancel'), :back, class: 'btn btn-outline-secondary mt-2' %>

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -95,7 +95,9 @@ en:
     delete: Delete
     labels:
       name: Name
+      lead: Lead
       leaders: Leads
+      member: Member
       members: Members
     save: Save
     notice:

--- a/spec/features/admin/user_groups/edit_spec.rb
+++ b/spec/features/admin/user_groups/edit_spec.rb
@@ -9,10 +9,10 @@ describe 'Admin edits a user group', type: :feature, js: true do
   let!(:group_type) do
     create(:group_type, name: 'Band')
   end
-  let!(:user_group) do
+  let!(:band1_group) do
     create(:user_group, group_type: group_type, name: 'Band 1')
   end
-  let!(:other_user_group) do
+  let!(:band2_group) do
     create(:user_group, group_type: group_type, name: 'Band 2')
   end
 
@@ -27,7 +27,7 @@ describe 'Admin edits a user group', type: :feature, js: true do
     click_button I18n.t('user_groups.save')
 
     expect(page).to have_content(I18n.t('user_groups.notice.successfully.updated'))
-    expect(user_group.reload.name).to eq 'NHS Band 1'
+    expect(band1_group.reload.name).to eq 'NHS Band 1'
   end
 
   context 'when enter non unique name' do
@@ -42,7 +42,7 @@ describe 'Admin edits a user group', type: :feature, js: true do
       click_button I18n.t('user_groups.save')
 
       expect(page).to have_content(I18n.t('user_groups.notice.could_not_be.updated'))
-      expect(user_group.reload.name).to eq 'Band 1'
+      expect(band1_group.reload.name).to eq 'Band 1'
     end
   end
 end

--- a/spec/features/admin/user_groups/set_lead_spec.rb
+++ b/spec/features/admin/user_groups/set_lead_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe 'Admin edits a user group', type: :feature, js: true do
+  let(:admin) do
+    create(:admin, first_name: 'John',
+                   last_name: 'Smith',
+                   email: 'john@example.com')
+  end
+  let!(:group_type) do
+    create(:group_type, name: 'Band')
+  end
+  let!(:user_group) do
+    create(:user_group, group_type: group_type, name: 'Band 1')
+  end
+  let!(:membership) { create(:membership, user_group: user_group, user: create(:user)) }
+
+  context 'when user group has members' do
+    it 'can set a memebr to be a lead of the group' do
+      visit edit_admin_user_group_path(user_group)
+
+      choose(I18n.t('user_groups.labels.lead'))
+      click_button I18n.t('user_groups.save')
+      expect(page).to have_content(I18n.t('user_groups.notice.successfully.updated'))
+      expect(user_group.reload.name).to eq 'Band 1'
+    end
+  end
+end

--- a/spec/features/admin/users/add_to_group_spec.rb
+++ b/spec/features/admin/users/add_to_group_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe 'Admin adds a user to a group', type: :feature, js: true do
+  let(:admin) do
+    create(:admin, first_name: 'John',
+                   last_name: 'Smith',
+                   email: 'john@example.com')
+  end
+  let(:user) do
+    create(:user)
+  end
+  let!(:group_type) do
+    create(:group_type, name: 'Band')
+  end
+  let!(:band1_group) do
+    create(:user_group, group_type: group_type, name: 'Band 1')
+  end
+  let!(:band2_group) do
+    create(:user_group, group_type: group_type, name: 'Band 2')
+  end
+
+  it 'updates user group' do
+    visit edit_admin_user_path(user)
+
+    expect(page).to have_bootstrap_select('Band', options: ['', 'Band 1', 'Band 2'])
+    bootstrap_select 'Band 2', from: 'Band'
+    click_button I18n.t('users.save')
+
+    expect(page).to have_content(I18n.t('users.notice.successfully.updated'))
+    expect(user.user_groups.first.name).to eq 'Band 2'
+  end
+end

--- a/spec/support/capybara_helpers.rb
+++ b/spec/support/capybara_helpers.rb
@@ -2,4 +2,11 @@ module CapybaraHelpers
   def have_bootstrap_select(*args)
     have_select(args.first, **args.last.merge(visible: false))
   end
+
+  def bootstrap_select(value, attrs)
+    within find('label', text: attrs[:from].to_s).find(:xpath, '..') do
+      find('button.dropdown-toggle').click
+      find('.dropdown-menu li', text: value).click
+    end
+  end
 end


### PR DESCRIPTION
Quick UI for adding users to groups and then being able to set them as the 'lead'.
Maybe not the best interface but see what you think. Shouldn't be needed much it in theory if we can pull this data from the ESR Wrapper once connected!