### PR TITLE
Increase docker-compose timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,3 +89,6 @@ AUTH0_CLIENT_SECRET=abc
 # Auth0 Token
 AUTH0_TOKEN_ISSUER=https://sardjv-dev.eu.auth0.com/
 AUTH0_TOKEN_AUDIENCE=https://job-plan-stats.herokuapp.com/api
+
+# Increase docker-compose timeout in case of slow internet.
+COMPOSE_HTTP_TIMEOUT=300


### PR DESCRIPTION
- Docker-compose was timing out a lot on startup when my internet was flaky, this fixed it
- Not sure why it needs to hit the internet when starting up, some kind of check I guess