### PR TITLE
Bump Ruby

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ orbs:
 jobs:
   build: # our first job, named "build"
     docker:
-      - image: cimg/ruby:2.7-node # use a tailored CircleCI docker image.
+      - image: cimg/ruby:2.7.2-node # use a tailored CircleCI docker image.
     steps:
       - checkout # pull down our git code.
       - ruby/install-deps # use the ruby orb to install dependencies
@@ -26,7 +26,7 @@ jobs:
     # this splits our tests across multiple containers.
     parallelism: 1
     docker:
-      - image: cimg/ruby:2.7-node # this is our primary docker image, where step commands run.
+      - image: cimg/ruby:2.7.2-node # this is our primary docker image, where step commands run.
       - image: circleci/mysql:8.0.19
         command: [--default-authentication-plugin=mysql_native_password]
         environment:

--- a/.env.example
+++ b/.env.example
@@ -39,17 +39,8 @@ DB_DATABASE=murfin_method
 DB_PORT=3306
 DB_HOST=db
 
-# Used on initial startup for PostgreSQL.
-POSTGRES_USERNAME=postgres
-POSTGRES_PASSWORD=root
-
 # Used on initial startup for MySQL.
 MYSQL_ROOT_PASSWORD=root
-
-# Used by SQL Server container.
-SQL_SERVER_USERNAME=sa
-SA_PASSWORD=Change_this_password123
-ACCEPT_EULA=Y
 
 # The full Redis URL for the Redis cache.
 REDIS_CACHE_URL=redis://:yourpassword@redis:6379/0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.1-alpine
+FROM ruby:2.7.2-alpine
 
 RUN apk update
 RUN apk add build-base git nodejs yarn

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM ruby:2.7.1-alpine
 
-# RUN apk update && apk add build-base git nodejs yarn postgresql-dev # PostgreSQL option.
-RUN apk update && apk add build-base git nodejs yarn mysql-dev # MySQL option.
-# RUN apk update && apk add build-base git nodejs yarn freetds-dev # SQL Server option.
+RUN apk update
+RUN apk add build-base git nodejs yarn
+RUN apk add mysql-dev
 
 RUN mkdir /app
 WORKDIR /app

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+ruby '2.7.2'
 
 # Make it easy to create beautiful-looking forms using Bootstrap 4.
 # https://github.com/bootstrap-ruby/bootstrap_form

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Core dependencies:
 - Rails 6.0.2.1 [https://github.com/rails/rails](https://github.com/rails/rails)
 - Redis 5.0.8 [https://redis.io/](https://redis.io/)
 - Sidekiq 6.0.6 [https://github.com/mperham/sidekiq](https://github.com/mperham/sidekiq)
-- PostgreSQL 12.2, MySQL 8.0.19 or SQL Server 2017
+- MySQL 8.0.19
 - Multiple supporting gems as listed in the Gemfile, Bundler (included in Ruby) should take care of installing these.
 
 ## Documentation

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,6 +1,5 @@
 ---
 
-# MySQL option.
 default: &default
   adapter: mysql2
   encoding: utf8mb4

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,14 +1,5 @@
 ---
 
-# PostgreSQL option.
-# default: &default
-#   adapter: postgresql
-#   encoding: unicode
-#   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-#   username: <%= ENV['POSTGRES_USERNAME'] %>
-#   password: <%= ENV['POSTGRES_PASSWORD'] %>
-#   host:  <%= ENV['DB_HOST'] %>
-
 # MySQL option.
 default: &default
   adapter: mysql2
@@ -21,16 +12,6 @@ default: &default
   port: <%= ENV['DB_PORT'] %>
   host: <%= ENV['DB_HOST'] %>
   socket: /var/run/mysqld/mysqlx.sock
-
-# SQL Server option.
-# default: &default
-#   adapter: sqlserver
-#   pool: 5
-#   timeout: 60000
-#   encoding: utf8
-#   host: <%= ENV['DB_HOST'] %>
-#   username: <%= ENV['SQL_SERVER_USERNAME'] %>
-#   password: <%= ENV['SA_PASSWORD'] %>
 
 development:
   <<: *default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,6 @@
 version: '3.7'
 
 services:
-  # PostgresSQL option.
-  # db:
-  #   image: 'postgres:12.2-alpine'
-  #   volumes:
-  #     - 'db:/var/lib/postgresql/data'
-  #   env_file:
-  #     - '.env'
-
-  # MySQL option.
   db:
     image: 'mysql:8.0.19'
     restart: always
@@ -19,16 +10,6 @@ services:
       - '.env'
     ports:
       - '3307:3306'
-
-  # SQL Server option.
-  # db:
-  #   image: microsoft/mssql-server-linux:2017-latest
-  #   volumes:
-  #     - 'db:/var/lib/sql_server'
-  #   env_file:
-  #     - '.env'
-  #   ports:
-  #     - '3307:1433'
 
   redis:
     image: 'redis:6.0.1-alpine'


### PR DESCRIPTION
- Bump Ruby version
- Remove config for other DBs for now - we're not testing them and I think the SQL Server version is broken, after fixing it on ESR. Can bring them across from ESR API if needed in the future.