### PR TITLE
#175910096 Remove presence validation on belongs_to associations.

### DIFF
--- a/app/models/activity_tag.rb
+++ b/app/models/activity_tag.rb
@@ -12,6 +12,5 @@ class ActivityTag < ApplicationRecord
   belongs_to :tag
   belongs_to :activity
 
-  validates :tag_id, :activity_id, presence: true
   validates :activity_id, uniqueness: { scope: :tag_id }
 end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -15,6 +15,6 @@ class Membership < ApplicationRecord
   belongs_to :user_group
   belongs_to :user
 
-  validates :user_group, presence: true, uniqueness: { scope: :user }
-  validates :user, :role, presence: true
+  validates :role, presence: true
+  validates :user_group, uniqueness: { scope: :user }
 end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -17,7 +17,7 @@ class Plan < ApplicationRecord
   has_many :activities, dependent: :destroy
   accepts_nested_attributes_for :activities, allow_destroy: true
 
-  validates :start_date, :end_date, :user_id, presence: true
+  validates :start_date, :end_date, presence: true
   validate :validate_end_date_after_start_date
 
   def validate_end_date_after_start_date

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -13,6 +13,6 @@ class Tag < ApplicationRecord
 
   has_many :activity_tags, dependent: :destroy
 
-  validates :name, :tag_type_id, presence: true
+  validates :name, presence: true
   validates :name, uniqueness: { scope: :tag_type_id, case_sensitive: false }
 end

--- a/app/models/time_range.rb
+++ b/app/models/time_range.rb
@@ -15,7 +15,7 @@ class TimeRange < ApplicationRecord
   belongs_to :user, touch: true
   belongs_to :time_range_type
 
-  validates :start_time, :end_time, :value, :time_range_type_id, :user_id, presence: true
+  validates :start_time, :end_time, :value, presence: true
   validate :validate_end_time_after_start_time
 
   def seconds_worked=(seconds)

--- a/spec/models/activity_tag_spec.rb
+++ b/spec/models/activity_tag_spec.rb
@@ -13,9 +13,7 @@ describe ActivityTag, type: :model do
 
   it { expect(subject).to be_valid }
   it { should belong_to(:tag) }
-  it { should validate_presence_of(:tag_id) }
   it { should belong_to(:activity) }
-  it { should validate_presence_of(:activity_id) }
   it { should have_db_index(%i[tag_id activity_id]).unique }
   it { should validate_uniqueness_of(:activity_id).scoped_to(:tag_id) }
 end

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -15,8 +15,8 @@ describe Membership, type: :model do
   subject { build(:membership) }
 
   it { expect(subject).to be_valid }
-  it { should validate_presence_of(:user_group) }
-  it { should validate_presence_of(:user) }
+  it { should belong_to(:user) }
+  it { should belong_to(:user_group) }
   it { should validate_presence_of(:role) }
   it { should have_db_index(%i[user_group_id user_id]).unique }
 end

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -16,10 +16,27 @@ describe Plan, type: :model do
 
   it { should validate_presence_of(:start_date) }
   it { should validate_presence_of(:end_date) }
-  it { should validate_presence_of(:user_id) }
   it { should belong_to(:user) }
   it { should have_many(:activities).dependent(:destroy) }
   it { should accept_nested_attributes_for(:activities).allow_destroy(true) }
+
+  context 'with nil user_id' do
+    subject { build(:plan, user_id: nil) }
+    it 'validates existence of user' do
+      expect(subject).not_to be_valid
+      messages = subject.errors.full_messages
+      expect(messages).to include('User must exist')
+    end
+  end
+
+  context 'with non existent user' do
+    subject { build(:plan, user_id: 123) }
+    it 'validates existence of user' do
+      expect(subject).not_to be_valid
+      messages = subject.errors.full_messages
+      expect(messages).to include('User must exist')
+    end
+  end
 
   context 'with end_date before start_date' do
     subject { build(:plan) }

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -14,7 +14,6 @@ describe Tag, type: :model do
   it { expect(subject).to be_valid }
   it { should validate_presence_of(:name) }
   it { should belong_to(:tag_type) }
-  it { should validate_presence_of(:tag_type_id) }
   it { should have_many(:activity_tags).dependent(:destroy) }
   it { should have_db_index(%i[tag_type_id name]).unique }
   it { should validate_uniqueness_of(:name).scoped_to(:tag_type_id).ignoring_case_sensitivity }

--- a/spec/models/time_range_spec.rb
+++ b/spec/models/time_range_spec.rb
@@ -19,9 +19,7 @@ describe TimeRange, type: :model do
   it { should validate_presence_of(:start_time) }
   it { should validate_presence_of(:end_time) }
   it { should validate_presence_of(:value) }
-  it { should validate_presence_of(:time_range_type_id) }
   it { should belong_to(:time_range_type) }
-  it { should validate_presence_of(:user_id) }
   it { should belong_to(:user) }
 
   describe '#value' do


### PR DESCRIPTION
Rails 5 changed the behaviour of belongs_to so it is defined as required by default, see https://github.com/rails/rails/issues/18233

The belongs_to matcher checks for the implicit presence validation to be present, but I added a couple of tests to plan_spec.rb just to try it out.

