### PR TITLE
#176437313 Show team job plans on team dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2021-01-14
+
+### Added
+
+- Team leads access team job plans.
+- Admins to see all job plans under the admin section.
+
+### Fixed
+
+- User dashboard to show just your own job plans and any to sign off.
+
 ## [0.9.1] - 2020-12-18
 
 ### Added

--- a/app/controllers/admin/plans_controller.rb
+++ b/app/controllers/admin/plans_controller.rb
@@ -1,0 +1,5 @@
+class Admin::PlansController < ApplicationController
+  def index
+    @plans = Plan.order(updated_at: :desc).page(params[:page])
+  end
+end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,6 +1,7 @@
 class TeamsController < ApplicationController
+  before_action :find_user_group
+
   def dashboard
-    @user_group = UserGroup.find(params[:id])
     @presenter = DashboardPresenter.new(params: team_params.merge(user_ids: @user_group.user_ids))
 
     respond_to do |format|
@@ -12,7 +13,6 @@ class TeamsController < ApplicationController
   end
 
   def individuals
-    @user_group = UserGroup.find(params[:id])
     @presenter = DashboardPresenter.new(params: team_params.merge(user_ids: @user_group.user_ids))
 
     respond_to do |format|
@@ -24,11 +24,14 @@ class TeamsController < ApplicationController
   end
 
   def plans
-    @user_group = UserGroup.find(params[:id])
     @plans = Plan.where(user_id: @user_group.users.pluck(:id)).order(updated_at: :desc).page(params[:page])
   end
 
   private
+
+  def find_user_group
+    @user_group = UserGroup.find(params[:id])
+  end
 
   def team_params
     params.permit(:id, :format, :page, :user_ids, :plan_id, :actual_id,

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -23,6 +23,11 @@ class TeamsController < ApplicationController
     end
   end
 
+  def plans
+    @user_group = UserGroup.find(params[:id])
+    @plans = Plan.where(user_id: @user_group.users.pluck(:id)).order(updated_at: :desc).page(params[:page])
+  end
+
   private
 
   def team_params

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -15,8 +15,4 @@ class UserGroup < ApplicationRecord
   has_many :users, through: :memberships
 
   validates :name, presence: true, uniqueness: { scope: :group_type, case_sensitive: false }
-
-  def display_name
-    name.titleize
-  end
 end

--- a/app/policies/plan_policy.rb
+++ b/app/policies/plan_policy.rb
@@ -12,7 +12,9 @@ class PlanPolicy < ApplicationPolicy
   end
 
   def edit?
-    update? || record.signoffs.find_by(user_id: user.id).present?
+    update? ||
+      record.signoffs.find_by(user_id: user.id).present? ||
+      Membership.where(user_group_id: record.user.user_group_ids, role: 'lead', user_id: user.id).any?
   end
 
   def destroy?
@@ -32,12 +34,8 @@ class PlanPolicy < ApplicationPolicy
     end
 
     def resolve
-      if user.admin?
-        scope.all
-      else
-        scope.left_joins(:signoffs)
-             .where('plans.user_id = :id OR signoffs.user_id = :id', id: user.id)
-      end
+      scope.left_joins(:signoffs)
+           .where('plans.user_id = :id OR signoffs.user_id = :id', id: user.id)
     end
   end
 end

--- a/app/policies/plan_policy.rb
+++ b/app/policies/plan_policy.rb
@@ -14,7 +14,7 @@ class PlanPolicy < ApplicationPolicy
   def edit?
     update? ||
       record.signoffs.find_by(user_id: user.id).present? ||
-      Membership.where(user_group_id: record.user.user_group_ids, role: 'lead', user_id: user.id).any?
+      Membership.exists?(user_group_id: record.user.user_group_ids, role: 'lead', user_id: user.id)
   end
 
   def destroy?

--- a/app/presenters/nav_presenter.rb
+++ b/app/presenters/nav_presenter.rb
@@ -35,6 +35,9 @@ class NavPresenter
           { label: I18n.t('nav.tabs.time_ranges'),
             path: %i[admin time_ranges],
             controllers: ['admin/time_ranges'] },
+          { label: I18n.t('nav.tabs.plans'),
+            path: %i[admin plans],
+            controllers: ['admin/plans'] },
           { label: I18n.t('nav.tabs.tags'),
             path: %i[admin tag_types],
             controllers: ['admin/tag_types'] }
@@ -46,10 +49,10 @@ class NavPresenter
 
   def team_subnav(team)
     {
-      label: team.display_name,
+      label: team.name,
       path: [:dashboard, :team, { id: team }],
       controllers: ['teams'],
-      actions: %w[dashboard individuals]
+      actions: %w[dashboard individuals plans]
     }
   end
 

--- a/app/views/admin/group_types/_group_type_card.html.erb
+++ b/app/views/admin/group_types/_group_type_card.html.erb
@@ -18,7 +18,7 @@
 
   <div id='collapse<%=index%>' class='collapse' aria-labelledby='heading<%=index%>' data-parent='#accordion'>
     <div class='card-body p-0'>
-      <%= render(partial: 'group_type_table', locals: { group_type: group_type}) %>
+      <%= render(partial: 'group_type_table', locals: { group_type: group_type }) %>
     </div>
   </div>
 </div>

--- a/app/views/admin/plans/index.html.erb
+++ b/app/views/admin/plans/index.html.erb
@@ -1,0 +1,9 @@
+<div class='container my-4'>
+  <div class='row'>
+    <div class='col-12'>
+
+      <%= render(partial: 'plans/plans', locals: { plans: @plans }) %>
+      
+    </div>
+  </div>
+</div>

--- a/app/views/plans/_plans.html.erb
+++ b/app/views/plans/_plans.html.erb
@@ -1,0 +1,61 @@
+<div class='table-responsive'>
+  <table class='table table-bordered'>
+    <thead>
+      <tr>
+        <th>
+          <%= Plan.human_attribute_name('name') %>
+        </th>
+        <th>
+          <%= Plan.human_attribute_name('start_date') %>
+        </th>
+        <th>
+          <%= Plan.human_attribute_name('end_date') %>
+        </th>
+        <th>
+          <%= Plan.human_attribute_name('state') %>
+        </th>
+        <th style='width: 50px;'></th>
+        <th style='width: 50px;'></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% plans.each do |plan| %>
+        <% cache plan do %>
+          <tr>
+            <td>
+              <%= plan.name %>
+            </td>
+            <td>
+              <%= I18n.l(plan.start_date, format: :readable) %>
+            </td>
+            <td>
+              <%= I18n.l(plan.end_date, format: :readable) %>
+            </td>
+            <td>
+              <h4 class='text-white'>
+                <span class='badge <%= state_badge_colour(plan) %>'>
+                  <%= display_state(plan) %>
+                </span>
+              </h4>
+            </td>
+            <td>
+              <% if policy(plan).edit? %>
+                <%= link_to [:edit, plan], class: 'btn btn-link' do %>
+                  <%= icon('pencil') %>
+                <% end %>
+              <% end %>
+            </td>
+            <td>
+              <% if policy(plan).destroy? %>
+                <%= link_to [plan], method: :delete, data: { confirm: I18n.t('actions.confirm') }, class: 'btn btn-link'  do %>
+                  <%= icon('trash') %>
+                <% end %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+<%= paginate @plans %>

--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -9,67 +9,7 @@
         <%= I18n.t('actions.add', model_name: Plan.model_name.human.titleize) %>
       <% end %>
 
-      <div class='table-responsive'>
-        <table class='table table-bordered'>
-          <thead>
-            <tr>
-              <th>
-                <%= Plan.human_attribute_name('name') %>
-              </th>
-              <th>
-                <%= Plan.human_attribute_name('start_date') %>
-              </th>
-              <th>
-                <%= Plan.human_attribute_name('end_date') %>
-              </th>
-              <th>
-                <%= Plan.human_attribute_name('state') %>
-              </th>
-              <th style='width: 50px;'></th>
-              <th style='width: 50px;'></th>
-            </tr>
-          </thead>
-          <tbody>
-            <% @plans.each do |plan| %>
-              <% cache plan do %>
-                <tr>
-                  <td>
-                    <%= plan.name %>
-                  </td>
-                  <td>
-                    <%= I18n.l(plan.start_date, format: :readable) %>
-                  </td>
-                  <td>
-                    <%= I18n.l(plan.end_date, format: :readable) %>
-                  </td>
-                  <td>
-                    <h4 class='text-white'>
-                      <span class='badge <%= state_badge_colour(plan) %>'>
-                        <%= display_state(plan) %>
-                      </span>
-                    </h4>
-                  </td>
-                  <td>
-                    <% if policy(plan).edit? %>
-                      <%= link_to [:edit, plan], class: 'btn btn-link' do %>
-                        <%= icon('pencil') %>
-                      <% end %>
-                    <% end %>
-                  </td>
-                  <td>
-                    <% if policy(plan).destroy? %>
-                      <%= link_to [plan], method: :delete, data: { confirm: I18n.t('actions.confirm') }, class: 'btn btn-link'  do %>
-                        <%= icon('trash') %>
-                      <% end %>
-                    <% end %>
-                  </td>
-                </tr>
-              <% end %>
-            <% end %>
-          </tbody>
-        </table>
-      </div>
-      <%= paginate @plans %>
+      <%= render(partial: 'plans', locals: { plans: @plans }) %>
 
     </div>
   </div>

--- a/app/views/teams/_team_tabs.html.erb
+++ b/app/views/teams/_team_tabs.html.erb
@@ -5,10 +5,13 @@
       locals: {
         tabs: [
           {
-            label: I18n.t('nav.tabs.team', team_name: @user_group.display_name), path: [:dashboard, :team, id: @user_group]
+            label: I18n.t('nav.tabs.team', team_name: @user_group.name), path: [:dashboard, :team, id: @user_group]
           },
           {
             label: I18n.t('nav.tabs.individuals'), path: [:individuals, :team, id: @user_group]
+          },
+          {
+            label: I18n.t('nav.tabs.plans'), path: [:plans, :team, id: @user_group]
           }
         ]
       }

--- a/app/views/teams/plans.html.erb
+++ b/app/views/teams/plans.html.erb
@@ -1,0 +1,7 @@
+<div class='container my-4'>
+
+  <%= render 'team_tabs' %>
+
+  <%= render(partial: 'plans/plans', locals: { plans: @plans }) %>
+
+</div>

--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,3 +1,3 @@
 module Murfin
-  VERSION = '0.9.1'.freeze
+  VERSION = '0.9.2'.freeze
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,9 +27,10 @@ Rails.application.routes.draw do
 
   resource :dashboard, only: :show, controller: 'dashboard'
 
-  resources :teams, only: %i[dashboard individuals] do
+  resources :teams, only: %i[dashboard individuals plans] do
     get :dashboard, on: :member
     get :individuals, on: :member
+    get :plans, on: :member
   end
 
   namespace :admin do
@@ -42,6 +43,7 @@ Rails.application.routes.draw do
     end
     resources :time_ranges, except: :show
     resources :users, except: :show
+    resources :plans, only: :index
   end
 
   resources :notes, except: :show

--- a/spec/features/admin/plans/index_spec.rb
+++ b/spec/features/admin/plans/index_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe 'Admin indexes plans', type: :feature, js: true do
+  let(:current_user) { create(:user, admin: true) }
+  let!(:plan) { create(:plan, user: current_user) }
+  let!(:other_plan) { create(:plan, user: create(:user)) }
+  let!(:signoff_plan) { create(:plan, user: create(:user), signoffs: [create(:signoff, user: current_user)]) }
+
+  before do
+    log_in current_user
+    visit admin_plans_path
+  end
+
+  it 'shows all plans' do
+    expect(page).to have_content(plan.name)
+    expect(page).to have_content(other_plan.name)
+    expect(page).to have_content(signoff_plan.name)
+  end
+end

--- a/spec/features/plans/index_spec.rb
+++ b/spec/features/plans/index_spec.rb
@@ -17,16 +17,6 @@ describe 'User indexes plans', type: :feature, js: true do
     expect(page).to have_content(signoff_plan.name)
   end
 
-  context 'when admin' do
-    let(:current_user) { create(:user, admin: true) }
-
-    it 'shows all plans' do
-      expect(page).to have_content(plan.name)
-      expect(page).to have_content(other_plan.name)
-      expect(page).to have_content(signoff_plan.name)
-    end
-  end
-
   context 'when a user name is updated' do
     let(:new_name) { 'Hirthe'.freeze }
 

--- a/spec/features/teams/dashboard_spec.rb
+++ b/spec/features/teams/dashboard_spec.rb
@@ -42,7 +42,7 @@ describe 'Team Dashboard ', type: :feature, js: true do
 
   it 'renders' do
     visit dashboard_team_path(user_group)
-    expect(page).to have_text 'Cahms dashboard'
+    expect(page).to have_text 'CAHMS dashboard'
   end
 
   describe 'notes' do

--- a/spec/features/teams/plans_spec.rb
+++ b/spec/features/teams/plans_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe 'Manager indexes plans', type: :feature, js: true do
+  let!(:manager) { create(:user) }
+  let!(:user_group) { create(:user_group) }
+  let!(:lead_membership) { create(:membership, user_group: user_group, user: manager, role: 'lead') }
+  let!(:team_member) { create(:user) }
+  let!(:team_member_membership) { create(:membership, user_group: user_group, user: team_member) }
+
+  let!(:manager_plan) { create(:plan, user: manager) }
+  let!(:team_member_plan) { create(:plan, user: team_member) }
+  let!(:other_plan) { create(:plan, user: create(:user)) }
+  let!(:signoff_plan) { create(:plan, user: create(:user), signoffs: [create(:signoff, user: manager)]) }
+
+  before do
+    log_in manager
+    visit plans_team_path(user_group)
+  end
+
+  it 'shows plans for the team' do
+    expect(page).to have_content(manager_plan.name)
+    expect(page).to have_content(team_member_plan.name)
+    expect(page).not_to have_content(other_plan.name)
+    expect(page).not_to have_content(signoff_plan.name)
+  end
+end


### PR DESCRIPTION
User dashboard to show just your own job plans and any to sign off.
Team leads to see team job plans (N.B. they don't currently have
permission to edit activities, so can only view the job plan).
Admins to see all job plans under the admin section.