### PR TITLE
#176640108 Login redirects to home page without bringing up Auth0 login

### DIFF
--- a/app/controllers/auth0_controller.rb
+++ b/app/controllers/auth0_controller.rb
@@ -3,7 +3,10 @@ class Auth0Controller < ApplicationController
   include LogoutHelper
 
   def callback
-    session[:userinfo] = request.env['omniauth.auth']
+    user_id = find_or_create_user(request.env['omniauth.auth'])
+    return redirect_to root_path, alert: I18n.t('notice.login_error') unless user_id
+
+    session[:user_id] = user_id
     redirect_to dashboard_path
   end
 
@@ -14,7 +17,18 @@ class Auth0Controller < ApplicationController
 
   def destroy
     reset_session
-    flash.notice = 'You have been logged out.'
+    flash.notice = I18n.t('notice.logged_out')
     redirect_to logout_url.to_s
+  end
+
+  private
+
+  def find_or_create_user(auth_info)
+    user = User.find_or_initialize_by(email: auth_info.dig(:info, 'email'))
+    return user.id if user.persisted?
+
+    user.first_name = auth_info.dig(:extra, :raw_info, :given_name)
+    user.last_name = auth_info.dig(:extra, :raw_info, :family_name)
+    user.id if user.save
   end
 end

--- a/app/controllers/concerns/secured_with_oauth.rb
+++ b/app/controllers/concerns/secured_with_oauth.rb
@@ -2,12 +2,12 @@ module SecuredWithOauth
   extend ActiveSupport::Concern
 
   def user_authenticated?
-    session && session[:userinfo].present?
+    session && session[:user_id].present?
   end
 
   def authenticate_user!
     if user_authenticated?
-      @current_user = find_or_create_user
+      @current_user = User.find(session[:user_id])
     else
       redirect_to root_path
     end
@@ -15,19 +15,5 @@ module SecuredWithOauth
 
   def current_user
     @current_user
-  end
-
-  private
-
-  def find_or_create_user
-    user = User.find_or_initialize_by(email: session.dig(:userinfo, 'info', 'email'))
-
-    unless user.persisted?
-      user.first_name = session.dig(:userinfo, 'extra', 'raw_info', 'given_name')
-      user.last_name = session.dig(:userinfo, 'extra', 'raw_info', 'family_name')
-      user.save!
-    end
-
-    user
   end
 end

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -104,6 +104,10 @@ en:
       destroyed:
         "%{model_name} could not be deleted"
     forbidden: You are not authorized to perform this action!
+    login_error:
+      There was a problem logging in. Please contact your administrator
+    logged_out:
+      You have been logged out
     successfully:
       created:
         "%{model_name} successfully created"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
   mount Rswag::Ui::Engine => 'api_docs'
   mount Rswag::Api::Engine => 'api_docs'
 
-  constraints ->(request) { request.session[:userinfo].present? } do
+  constraints ->(request) { request.session[:user_id].present? } do
     mount Sidekiq::Web => '/sidekiq'
   end
 

--- a/spec/requests/auth_spec.rb
+++ b/spec/requests/auth_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 RSpec.describe 'Auth', type: :request do
   describe 'GET admin_dashboard_path' do
     let(:user) do
-      build(:user,
-            first_name: 'John',
-            last_name: 'Smith',
-            email: 'john@example.com')
+      create(:user,
+             first_name: 'John',
+             last_name: 'Smith',
+             email: 'john@example.com')
     end
     context 'when authenticated' do
       before do
@@ -16,10 +16,6 @@ RSpec.describe 'Auth', type: :request do
       it 'returns http success' do
         get admin_dashboard_path
         expect(response).to have_http_status(:success)
-      end
-
-      it 'creates a user' do
-        expect { get admin_dashboard_path }.to change { User.count }.by(1)
       end
 
       it 'sets the user name and email' do

--- a/spec/requests/notes_spec.rb
+++ b/spec/requests/notes_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Notes', type: :request do
   before do
-    log_in(build(:user))
+    log_in(create(:user))
   end
 
   describe 'GET /notes/new' do

--- a/spec/support/request_session_helpers.rb
+++ b/spec/support/request_session_helpers.rb
@@ -3,7 +3,7 @@ module RequestSessionHelpers
     if ENV['AUTH_METHOD'] == 'form'
       login_as user, scope: :user # from Devise https://github.com/heartcombo/devise/wiki/How-To:-Test-with-Capybara
     else
-      allow_any_instance_of(ApplicationController).to receive(:session).and_return(userinfo: mock_valid_auth_hash(user))
+      allow_any_instance_of(ApplicationController).to receive(:session).and_return(user_id: user.id)
     end
   end
 end


### PR DESCRIPTION
Fix for log in bug that's seen when try to login with more than one
gmail account. Possibly related to a CookieOverflow I was getting
occasionally. Refactor to only store user_id in session and create user
in Auth0 callback.