### PR TITLE
gem: update jsonapi-resources.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,10 +35,7 @@ gem 'ice_cube', '~> 0.16.3'
 
 # A resource-focused Rails library for developing JSON:API compliant servers.
 # https://github.com/cerebris/jsonapi-resources
-# Use specified version until jsonapi-resources version after 0.10.2 is released.
-# This is so we can use this PR https://github.com/cerebris/jsonapi-resources/pull/1346
-# for Rails 6.1.1 compatibility.
-gem 'jsonapi-resources', github: 'cerebris/jsonapi-resources', ref: 'eb432722b915e76914be9132e010a1244a32e91c'
+gem 'jsonapi-resources', '~> 0.10.4'
 
 # A ruby implementation of the RFC 7519 OAuth JSON Web Token (JWT) standard.
 # https://github.com/jwt/ruby-jwt

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,16 +9,6 @@ GIT
       rubyzip (>= 1.2.2)
       websocket (~> 1.0)
 
-GIT
-  remote: https://github.com/cerebris/jsonapi-resources.git
-  revision: eb432722b915e76914be9132e010a1244a32e91c
-  ref: eb432722b915e76914be9132e010a1244a32e91c
-  specs:
-    jsonapi-resources (0.11.0.beta1)
-      activerecord (>= 4.1)
-      concurrent-ruby
-      railties (>= 4.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -159,6 +149,10 @@ GEM
     ice_cube (0.16.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
+    jsonapi-resources (0.10.4)
+      activerecord (>= 4.1)
+      concurrent-ruby
+      railties (>= 4.1)
     jwt (2.2.2)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
@@ -387,7 +381,7 @@ DEPENDENCIES
   guard-rspec (~> 4.7.3)
   guard-rubocop (~> 1.4.0)
   ice_cube (~> 0.16.3)
-  jsonapi-resources!
+  jsonapi-resources (~> 0.10.4)
   jwt (~> 2.2.2)
   kaminari (~> 1.2.1)
   listen (~> 3.4.1)


### PR DESCRIPTION
@alexrudall seems that it should be now Rails 6.1 compatible https://github.com/cerebris/jsonapi-resources/commit/1322b5939767687cbc8a0942584aa36afb2bca83