### PR TITLE
Fix for ActiveRecord::RecordNotUnique

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,6 +91,10 @@ gem 'rswag-ui', '~> 2.4.0'
 # https://github.com/mperham/sidekiq
 gem 'sidekiq', '~> 6.2.0'
 
+# Strips attributes of leading and trailing whitespace before validation.
+# https://github.com/rmm5t/strip_attributes
+gem 'strip_attributes', '~> 1.11.0'
+
 # Bundle zoneinfo files which are not included in Windows.
 # https://github.com/tzinfo/tzinfo-data
 gem 'tzinfo-data', '~> 1.2021.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -345,6 +345,8 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sql_tracker (1.3.2)
+    strip_attributes (1.11.0)
+      activemodel (>= 3.0, < 7.0)
     temple (0.8.2)
     thor (1.1.0)
     tilt (2.0.10)
@@ -413,6 +415,7 @@ DEPENDENCIES
   sidekiq (~> 6.2.0)
   simplecov (~> 0.21.2)
   sql_tracker (~> 1.3.2)
+  strip_attributes
   timecop (~> 0.9.4)
   tzinfo-data (~> 1.2021.1)
   webpacker (~> 5.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -415,7 +415,7 @@ DEPENDENCIES
   sidekiq (~> 6.2.0)
   simplecov (~> 0.21.2)
   sql_tracker (~> 1.3.2)
-  strip_attributes
+  strip_attributes (~> 1.11.0)
   timecop (~> 0.9.4)
   tzinfo-data (~> 1.2021.1)
   webpacker (~> 5.2.1)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,7 @@
 #  epr_uuid               :string(255)
 #
 class User < ApplicationRecord
+  strip_attributes only: %i[first_name last_name email epr_uuid]
   # :confirmable, :lockable, :timeoutable, :recoverable, :trackable and :omniauthable
   devise :database_authenticatable, :validatable, :rememberable
 

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -10,6 +10,7 @@
             %tr
               %th= User.human_attribute_name('name')
               %th= User.human_attribute_name('email')
+              %th= User.human_attribute_name('epr_uuid')
               %th{style: "width: 50px;"}
               %th{style: "width: 50px;"}
           %tbody
@@ -22,6 +23,7 @@
                       %br/
                       Admin
                   %td= user.email
+                  %td= user.epr_uuid
                   %td
                     = link_to [:edit, :admin, user], class: 'btn btn-link' do
                       = icon('pencil')

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -10,14 +10,9 @@
             %tr
               %th= User.human_attribute_name('name')
               %th= User.human_attribute_name('email')
-<<<<<<< HEAD
               %th= User.human_attribute_name('epr_uuid')
-              %th{style: "width: 50px;"}
-              %th{style: "width: 50px;"}
-=======
               %th{ style: 'width: 50px;' }
               %th{ style: 'width: 50px;' }
->>>>>>> master
           %tbody
             - @users.each do |user|
               - cache user do

--- a/spec/api/v1/users/update_spec.rb
+++ b/spec/api/v1/users/update_spec.rb
@@ -84,6 +84,18 @@ describe Api::V1::UserResource, type: :request, swagger_doc: 'v1/swagger.json' d
           end
         end
 
+        context 'epr_uuid is null' do
+          let(:attributes) { valid_attributes.merge(epr_uuid: '') }
+
+          response '200', 'OK: User updated' do
+            schema '$ref' => '#/definitions/user_response'
+
+            run_test! do
+              expect(updated_user.reload.epr_uuid).to eql nil
+            end
+          end
+        end
+
         context 'user group relationships passed' do
           let!(:user_group1) { create :user_group }
           let!(:user_group2) { create :user_group }

--- a/spec/features/admin/users/edit_spec.rb
+++ b/spec/features/admin/users/edit_spec.rb
@@ -18,6 +18,16 @@ describe 'Admin edits a user', type: :feature, js: true do
     end
   end
 
+  context 'when remove epr_uuid' do
+    let!(:user_without_epr_uuid) { create :user, epr_uuid: '' }
+    it 'saves as nil to prevent ActiveRecord::RecordNotUnique' do
+      fill_in User.human_attribute_name('epr_uuid'), with: ''
+      click_button I18n.t('actions.save')
+      expect(page).to have_content(I18n.t('notice.successfully.updated', model_name: User.model_name.human))
+      expect(user.reload.epr_uuid).to eq nil
+    end
+  end
+
   context 'auth method is oauth' do
     around do |example|
       ClimateControl.modify AUTH_METHOD: 'oauth' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -28,4 +28,5 @@ describe User, type: :model do
   it { should validate_presence_of(:first_name) }
   it { should validate_presence_of(:last_name) }
   it { should validate_uniqueness_of(:epr_uuid).allow_blank }
+  it { is_expected.to strip_attributes(:first_name, :last_name, :email, :epr_uuid) }
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,6 +14,7 @@ Dir[File.join(__dir__, 'fixtures/', '*.rb')].sort.each { |file| require file }
 Dir[File.join(__dir__, 'support/', '*.rb')].sort.each { |file| require file }
 
 require 'rspec/retry'
+require 'strip_attributes/matchers'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -115,6 +116,7 @@ RSpec.configure do |config|
   config.include FeatureSessionHelpers, type: :feature
   config.include RequestSessionHelpers, type: :request
   config.include FormHelpers, type: :feature
+  config.include StripAttributes::Matchers
 
   config.include Warden::Test::Helpers
   config.include Devise::Test::IntegrationHelpers, type: :feature


### PR DESCRIPTION
Fix for ActiveRecord::RecordNotUnique when more than one user has blank epr_uuid.
strip_attributes will set the epr_uuid value to nil if it is blank.
Also strip first_name, last_name and email of leading and trailing
whitespace before validation.