### PR TITLE
Fixed Admin navbar to work on small screens

### DIFF
--- a/app/javascript/stylesheets/nav.scss
+++ b/app/javascript/stylesheets/nav.scss
@@ -3,13 +3,16 @@
   background-color: $yellow-500;
 }
 
-.page-footer {
-  border-top: 2px solid $primary;
-}
 
+
+// Top navbar ===================================
 .rootnav {
   padding-top: 0px;
   padding-bottom: 0px;
+
+  .navbar-toggler{
+    border: 1px solid white;
+  }
 
   .navbar-nav {
     .nav-link {
@@ -22,8 +25,16 @@
   }
 }
 
+
+
+// Admin navbar =================================
 .subnav {
   background-color: $grey-50;
+
+  .navbar-toggler{
+    border: 1px solid $grey-600;
+    // color: $grey-600;
+  }
 
   .nav-link {
     color: $grey-600;
@@ -34,7 +45,16 @@
   }
 }
 
-// Icons.
+
+
+// Footer =======================================
+.page-footer {
+  border-top: 2px solid $primary;
+}
+
+
+
+// Icons ========================================
 .bi-chevron-left, .bi-chevron-right {
   color: $grey-900;
 }

--- a/app/views/shared/_nav.html.haml
+++ b/app/views/shared/_nav.html.haml
@@ -1,4 +1,4 @@
-%nav.rootnav.navbar.navbar-expand-lg.navbar-dark.bg-primary
+%nav.rootnav.navbar.navbar-expand-md.navbar-dark.bg-primary
   .container
     %a.navbar-brand{ href: root_path }
       = image_pack_tag 'media/images/logos/murfin-plus-logo.svg', height: 50, class: 'ml-2', alt: 'Murfin+ logo'
@@ -22,9 +22,13 @@
         = render partial: 'shared/auth'
 - navs.each do |nav|
   - if presenter.any_subnavs_active?(nav) && nav[:enabled]
-    %nav.subnav.navbar.navbar-expand-lg
+    %nav.subnav.navbar.navbar-expand-lg.navbar-light
       .container
-        .collapse.navbar-collapse.pl-4
+        %a.navbar-brand.d-lg-none Admin Menu
+        %button.navbar-toggler{ 'aria-controls': 'subnav-content', 'aria-expanded': 'false', 'aria-label': 'Toggle navigation',
+                                'data-target': '#subnav-content', 'data-toggle': 'collapse', type: 'button' }
+          %span.navbar-toggler-icon
+        #subnav-content.collapse.navbar-collapse.pl-4
           - if user_authenticated?
             %ul.navbar-nav.mr-auto
               - nav[:subnavs].each do |subnav|

--- a/app/views/shared/_nav.html.haml
+++ b/app/views/shared/_nav.html.haml
@@ -24,7 +24,7 @@
   - if presenter.any_subnavs_active?(nav) && nav[:enabled]
     %nav.subnav.navbar.navbar-expand-lg.navbar-light
       .container
-        %a.navbar-brand.d-lg-none Admin Menu
+        %a.navbar-brand.d-lg-none
         %button.navbar-toggler{ 'aria-controls': 'subnav-content', 'aria-expanded': 'false', 'aria-label': 'Toggle navigation',
                                 'data-target': '#subnav-content', 'data-toggle': 'collapse', type: 'button' }
           %span.navbar-toggler-icon


### PR DESCRIPTION
I have fixed the Admin Navbar to work on small screens.
However if we ever add more items, it will probably need a redesign to allow the content to fit properly.
If you don't want the Title 'Admin Menu' to appear on small screens then remove it from line 27 on nav.html.haml, but keep the %a.navbar-brand.d-lg-none . It's used for alignment.